### PR TITLE
Fixed hashed passwords presented in KeePass app

### DIFF
--- a/src/kdbx.cc
+++ b/src/kdbx.cc
@@ -425,12 +425,12 @@ void KdbxFile::WriteMeta(pugi::xml_node& meta_node,
     bin_node.append_attribute("ID").set_value(binary_id);
 
     if (binary->data().is_protected()) {
-      bin_node.append_attribute("Protected").set_value(true);
+      bin_node.append_attribute("Protected").set_value("True");
       bin_node.text().set(base64_encode(obfuscator.Process(
           *binary->data())).c_str());
     } else {
       if (binary->compress()) {
-        bin_node.append_attribute("Compressed").set_value(true);
+        bin_node.append_attribute("Compressed").set_value("True");
         std::stringstream compressed_data;
 
         gzip_ostreambuf gzip_streambuf(compressed_data);

--- a/src/kdbx.cc
+++ b/src/kdbx.cc
@@ -190,7 +190,7 @@ void KdbxFile::WriteProtectedString(pugi::xml_node& node,
                                     const protect<std::string>& str,
                                     RandomObfuscator& obfuscator) const {
   if (str.is_protected()) {
-    node.append_attribute("Protected").set_value(true);
+    node.append_attribute("Protected").set_value("True");
     node.text().set(base64_encode(obfuscator.Process(*str)).c_str());
   } else {
     node.text().set(str->c_str());


### PR DESCRIPTION
Fixed issue with exported kdbx files: entries' passwords were presented hashed when opening the kdbx file with KeePass app (version 2.38 for Windows OS)